### PR TITLE
fix emails actions buttons issue

### DIFF
--- a/src/modules/email/seeders/email-templates/order-created.template.ts
+++ b/src/modules/email/seeders/email-templates/order-created.template.ts
@@ -28,10 +28,34 @@ export const orderCreatedTemplate = {
          </p>
       </div>
       <div style="text-align: center; margin: 30px 0;">
-         <a href="{{orderUrl}}" 
-            style="display: inline-block; padding: 16px 40px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; border-radius: 8px; font-size: 16px; font-weight: 600; box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);">
-         View My Order
-         </a>
+
+
+         <table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center">
+  <tr>
+    <td
+      bgcolor="#667eea"
+      style="
+        border-radius:8px;
+        text-align:center;
+      "
+    >
+      <a
+        href="{{orderUrl}}"
+        style="
+          display:inline-block;
+          padding:16px 40px;
+          font-size:16px;
+          font-weight:600;
+          font-family:'Cairo','Segoe UI',Arial,sans-serif;
+          color:#ffffff;
+          text-decoration:none;
+          line-height:1.2;
+        "
+      >
+View My Order      </a>
+    </td>
+  </tr>
+</table>
       </div>
       <p style="color: #999; font-size: 13px; line-height: 1.6;">
          If the button doesn’t work, you can open this link:<br>
@@ -163,10 +187,33 @@ export const orderCreatedTemplate = {
       </p>
    </div>
    <div style="text-align: center; margin: 30px 0;">
-      <a href="{{orderUrl}}" 
-         style="display: inline-block; padding: 16px 40px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; border-radius: 8px; font-size: 16px; font-weight: 600; box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);">
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center">
+  <tr>
+    <td
+      bgcolor="#667eea"
+      style="
+        border-radius:8px;
+        text-align:center;
+      "
+    >
+      <a
+        href="{{orderUrl}}"
+        style="
+          display:inline-block;
+          padding:16px 40px;
+          font-size:16px;
+          font-weight:600;
+          font-family:'Cairo','Segoe UI',Arial,sans-serif;
+          color:#ffffff;
+          text-decoration:none;
+          line-height:1.2;
+        "
+      >
       عرض الطلب
-      </a>
+     </a>
+    </td>
+  </tr>
+</table>
    </div>
    <p style="color: #999; font-size: 13px; line-height: 1.7;">
       إذا لم يعمل الزر، انسخ الرابط التالي والصقه في المتصفح:<br>

--- a/src/modules/email/seeders/email-templates/password-reset-success.template.ts
+++ b/src/modules/email/seeders/email-templates/password-reset-success.template.ts
@@ -25,10 +25,32 @@ export const passwordResetSuccessTemplate = {
          </p>
       </div>
       <div style="text-align: center; margin: 30px 0;">
-         <a href="{{loginUrl}}" 
-            style="display: inline-block; padding: 14px 36px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; border-radius: 8px; font-size: 16px; font-weight: 600; box-shadow: 0 4px 10px rgba(102, 126, 234, 0.4);">
-         Go to CartJO
-         </a>
+         <table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center">
+  <tr>
+    <td
+      bgcolor="#667eea"
+      style="
+        border-radius:8px;
+        text-align:center;
+      "
+    >
+      <a
+        href="{{loginUrl}}"
+        style="
+          display:inline-block;
+          padding:16px 40px;
+          font-size:16px;
+          font-weight:600;
+          font-family:'Cairo','Segoe UI',Arial,sans-serif;
+          color:#ffffff;
+          text-decoration:none;
+          line-height:1.2;
+        "
+      >
+Go to CartJO      </a>
+    </td>
+  </tr>
+</table>
       </div>
       <p style="color: #999; font-size: 13px; line-height: 1.5; margin: 25px 0 0 0;">
          If the button doesn’t work, copy and paste this link into your browser:<br>
@@ -153,10 +175,33 @@ export const passwordResetSuccessTemplate = {
       </p>
    </div>
    <div style="text-align: center; margin: 30px 0;">
-      <a href="{{loginUrl}}" 
-         style="display: inline-block; padding: 14px 36px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; border-radius: 8px; font-size: 16px; font-weight: 600; box-shadow: 0 4px 10px rgba(102, 126, 234, 0.4);">
+       <table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center">
+  <tr>
+    <td
+      bgcolor="#667eea"
+      style="
+        border-radius:8px;
+        text-align:center;
+      "
+    >
+      <a
+        href="{{loginUrl}}"
+        style="
+          display:inline-block;
+          padding:16px 40px;
+          font-size:16px;
+          font-weight:600;
+          font-family:'Cairo','Segoe UI',Arial,sans-serif;
+          color:#ffffff;
+          text-decoration:none;
+          line-height:1.2;
+        "
+      >
       الذهاب إلى كارت جو
       </a>
+    </td>
+  </tr>
+</table>
    </div>
    <p style="color: #999; font-size: 13px; line-height: 1.7; margin: 25px 0 0 0; text-align: right;">
       إذا لم يعمل الزر، انسخ هذا الرابط والصقه في المتصفح:<br>

--- a/src/modules/email/seeders/email-templates/resend-verification-email.template.ts
+++ b/src/modules/email/seeders/email-templates/resend-verification-email.template.ts
@@ -20,10 +20,33 @@ export const resendVerificationTemplate = {
          Please verify your email address below to activate your account.
       </p>
       <div style="text-align: center; margin: 30px 0;">
-         <a href="{{confirmationUrl}}" 
-            style="display: inline-block; padding: 16px 40px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; border-radius: 8px; font-size: 16px; font-weight: 600; box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);">
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center">
+  <tr>
+    <td
+      bgcolor="#667eea"
+      style="
+        border-radius:8px;
+        text-align:center;
+      "
+    >
+      <a
+        href="{{confirmationUrl}}"
+        style="
+          display:inline-block;
+          padding:16px 40px;
+          font-size:16px;
+          font-weight:600;
+          font-family:'Cairo','Segoe UI',Arial,sans-serif;
+          color:#ffffff;
+          text-decoration:none;
+          line-height:1.2;
+        "
+      >
          Verify My Email
-         </a>
+      </a>
+    </td>
+  </tr>
+</table>
       </div>
       <p style="color: #999; font-size: 13px; line-height: 1.5; margin: 25px 0 0 0;">
          If the button doesn't work, copy and paste this link into your browser:<br>
@@ -149,10 +172,34 @@ export const resendVerificationTemplate = {
           </p>
 
           <div style="text-align: center; margin: 30px 0;">
-            <a href="{{confirmationUrl}}" 
-              style="display: inline-block; padding: 16px 40px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; border-radius: 8px; font-size: 16px; font-weight: 600; box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);">
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center">
+  <tr>
+    <td
+      bgcolor="#667eea"
+      style="
+        border-radius:8px;
+        text-align:center;
+      "
+    >
+      <a
+        href="{{confirmationUrl}}"
+        style="
+          display:inline-block;
+          padding:16px 40px;
+          font-size:16px;
+          font-weight:600;
+          font-family:'Cairo','Segoe UI',Arial,sans-serif;
+          color:#ffffff;
+          text-decoration:none;
+          line-height:1.2;
+        "
+      >
               تحقق من البريد الإلكتروني
-            </a>
+      </a>
+    </td>
+  </tr>
+</table>
+
           </div>
 
           <p style="color: #999; font-size: 13px; line-height: 1.7; margin: 25px 0 0 0; text-align: right;">

--- a/src/modules/email/seeders/email-templates/user-registration.template.ts
+++ b/src/modules/email/seeders/email-templates/user-registration.template.ts
@@ -36,12 +36,33 @@ export const userRegistrationTemplate = {
          </p>
       </div>
       <div style="text-align:center;margin:30px 0;">
-         <a
-            href="{{confirmationUrl}}"
-            style="display:inline-block;padding:16px 40px;background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);color:#ffffff;text-decoration:none;border-radius:8px;font-size:16px;font-weight:600;box-shadow:0 4px 12px rgba(102,126,234,0.4);"
-            >
-         Confirm Email Address
-         </a>
+         <table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center">
+  <tr>
+    <td
+      bgcolor="#667eea"
+      style="
+        border-radius:8px;
+        text-align:center;
+      "
+    >
+      <a
+        href="{{confirmationUrl}}"
+        style="
+          display:inline-block;
+          padding:16px 40px;
+          font-size:16px;
+          font-weight:600;
+          font-family:'Cairo','Segoe UI',Arial,sans-serif;
+          color:#ffffff;
+          text-decoration:none;
+          line-height:1.2;
+        "
+      >
+Confirm Email Address      </a>
+    </td>
+  </tr>
+</table>
+
       </div>
       <p style="color:#999;font-size:13px;line-height:1.7;margin:25px 0 0 0;">
          If the button doesn’t work, copy and paste this link into your browser:<br />
@@ -184,12 +205,34 @@ export const userRegistrationTemplate = {
    </p>
 </div>
 <div style="text-align:center;margin:30px 0;">
-   <a
-      href="{{confirmationUrl}}"
-      style="display:inline-block;padding:16px 40px;background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);color:#ffffff;text-decoration:none;border-radius:8px;font-size:16px;font-weight:600;box-shadow:0 4px 12px rgba(102,126,234,0.4);"
+   <table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center">
+  <tr>
+    <td
+      bgcolor="#667eea"
+      style="
+        border-radius:8px;
+        text-align:center;
+      "
+    >
+      <a
+        href="{{confirmationUrl}}"
+        style="
+          display:inline-block;
+          padding:16px 40px;
+          font-size:16px;
+          font-weight:600;
+          font-family:'Cairo','Segoe UI',Arial,sans-serif;
+          color:#ffffff;
+          text-decoration:none;
+          line-height:1.2;
+        "
       >
-   تأكيد البريد الإلكتروني 
-   </a>
+        تأكيد البريد الإلكتروني
+      </a>
+    </td>
+  </tr>
+</table>
+
 </div>
 <p style="color:#999;font-size:13px;line-height:1.7;margin:25px 0 0 0;">
    إذا لم يعمل الزر، انسخ هذا الرابط وألصقه في المتصفح:<br />


### PR DESCRIPTION
Email clients (and SendGrid previews) often break or hide styled <a> elements, especially in Outlook and some mobile clients.

What you’re seeing (empty space) is a classic email-client rendering issue, not a SendGrid bug.
Use a table-based button

This works in Gmail, Outlook, Apple Mail, Yahoo, mobile.